### PR TITLE
Handle exceptions during scheduled check.

### DIFF
--- a/src/txacme/service.py
+++ b/src/txacme/service.py
@@ -121,7 +121,10 @@ class AcmeIssuingService(Service):
         return (
             self._register()
             .addCallback(lambda _: self.cert_store.as_dict())
-            .addCallback(check))
+            .addCallback(check)
+            .addErrback(
+                lambda f: log.failure(
+                    u'Error in scheduled certificate check.', f)))
 
     def _issue_cert(self, server_name):
         """


### PR DESCRIPTION
If an exception happens during re-issuing of a particular certificate, this will be caught and logged; but failures can occur outside of this (for example, during registration), and these will leak out of `_check_certs` causing the `TimerService` to enter a broken state. This branch changes the behaviour to catch and log all failures here so that the scheduled operation itself never fails.

Fixes #40.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mithrandi/txacme/52)
<!-- Reviewable:end -->
