### PR TITLE
Typecheck ACME directory URL arguments.

### DIFF
--- a/src/integration/test_client.py
+++ b/src/integration/test_client.py
@@ -64,7 +64,7 @@ class ClientTestsMixin(object):
         with action.context():
             return (
                 DeferredContext(
-                   self.client.request_challenges(fqdn_identifier(host)))
+                    self.client.request_challenges(fqdn_identifier(host)))
                 .addActionFinish())
 
     def _test_poll_pending(self, auth):

--- a/src/txacme/client.py
+++ b/src/txacme/client.py
@@ -25,7 +25,7 @@ from txacme.logging import (
     LOG_HTTP_PARSE_LINKS, LOG_JWS_ADD_NONCE, LOG_JWS_CHECK_RESPONSE,
     LOG_JWS_GET, LOG_JWS_GET_NONCE, LOG_JWS_HEAD, LOG_JWS_POST,
     LOG_JWS_REQUEST, LOG_JWS_SIGN)
-from txacme.util import tap
+from txacme.util import check_directory_url_type, tap
 
 
 LETSENCRYPT_DIRECTORY = URL.fromText(
@@ -128,6 +128,7 @@ class Client(object):
         action = LOG_ACME_CONSUME_DIRECTORY(
             url=url, key_type=key.typ, alg=alg.name)
         with action.context():
+            check_directory_url_type(url)
             jws_client = _default_client(jws_client, reactor, key, alg)
             return (
                 DeferredContext(jws_client.get(url.asText()))

--- a/src/txacme/endpoint.py
+++ b/src/txacme/endpoint.py
@@ -23,7 +23,7 @@ from txacme.challenges import TLSSNI01Responder
 from txacme.client import Client
 from txacme.service import _default_panic, AcmeIssuingService
 from txacme.store import DirectoryStore
-from txacme.util import generate_private_key
+from txacme.util import check_directory_url_type, generate_private_key
 
 
 @implementer(IListeningPort)
@@ -81,7 +81,8 @@ class AutoTLSEndpoint(object):
         key generation requirements.
     """
     reactor = attr.ib()
-    directory = attr.ib()
+    directory = attr.ib(
+        validator=lambda inst, a, value: check_directory_url_type(value))
     client_creator = attr.ib()
     cert_store = attr.ib()
     cert_mapping = attr.ib()

--- a/src/txacme/test/test_client.py
+++ b/src/txacme/test/test_client.py
@@ -268,6 +268,15 @@ class ClientTests(TestCase):
     """
     :class:`.Client` provides a client interface for the ACME API.
     """
+    def test_directory_url_type(self):
+        """
+        `~txacme.client.Client.from_url` expects a ``twisted.python.url.URL``
+        instance for the ``url`` argument.
+        """
+        with ExpectedException(TypeError):
+            Client.from_url(
+                reactor, '/wrong/kind/of/directory', key=RSA_KEY_512)
+
     def test_register_missing_next(self):
         """
         If the directory does not return a ``"next"`` link, a

--- a/src/txacme/test/test_endpoint.py
+++ b/src/txacme/test/test_endpoint.py
@@ -4,7 +4,7 @@ Tests for `txacme.endpoint`.
 from datetime import datetime
 
 from fixtures import TempDir
-from testtools import TestCase
+from testtools import ExpectedException, TestCase
 from testtools.matchers import (
     Equals, Is, IsInstance, MatchesAll, MatchesPredicate, MatchesStructure)
 from testtools.twistedsupport import succeeded
@@ -58,11 +58,25 @@ class EndpointTests(TestCase):
         client = FakeClient(RSA_KEY_512, clock)
         self.endpoint = AutoTLSEndpoint(
             reactor=clock,
-            directory=None,
+            directory=URL(u'https://example.com/'),
             client_creator=lambda reactor, directory: succeed(client),
             cert_store=MemoryStore(),
             cert_mapping={},
             sub_endpoint=DummyEndpoint())
+
+    def test_directory_url_type(self):
+        """
+        `~txacme.endpoint.AutoTLSEndpoint` expects a ``twisted.python.url.URL``
+        instance for the ``directory`` argument.
+        """
+        with ExpectedException(TypeError):
+            AutoTLSEndpoint(
+                reactor=Clock(),
+                directory='/wrong/kind/of/directory',
+                client_creator=None,
+                cert_store=None,
+                cert_mapping={},
+                sub_endpoint=DummyEndpoint())
 
     def test_listen_starts_service(self):
         """

--- a/src/txacme/util.py
+++ b/src/txacme/util.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from OpenSSL import crypto
 from twisted.internet.defer import maybeDeferred
+from twisted.python.url import URL
 
 
 def generate_private_key(key_type):
@@ -167,7 +168,19 @@ def clock_now(clock):
     return datetime.utcfromtimestamp(clock.seconds())
 
 
+def check_directory_url_type(url):
+    """
+    Check that ``url`` is a ``twisted.python.url.URL`` instance, raising
+    `TypeError` if it isn't.
+    """
+    if not isinstance(url, URL):
+        raise TypeError(
+            'ACME directory URL should be a twisted.python.url.URL, '
+            'got {!r} instead'.format(url))
+
+
 __all__ = [
     'generate_private_key', 'generate_tls_sni_01_cert',
     'cert_cryptography_to_pyopenssl', 'key_cryptography_to_pyopenssl', 'tap',
-    'encode_csr', 'decode_csr', 'csr_for_names', 'clock_now']
+    'encode_csr', 'decode_csr', 'csr_for_names', 'clock_now',
+    'check_directory_url_type']


### PR DESCRIPTION
Both `Client.from_url` and `AutoTLSEndpoint` accept an ACME directory
endpoint that must be a `twisted.python.url.URL` instance, making this
typecheck explicit means that even if you mix up the ACME directory and
`DirectoryStore` concepts you should get an error that points out the
problem in a considerably more obvious manner than it currently does.

Fixes #29.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mithrandi/txacme/56)
<!-- Reviewable:end -->
