### PR TITLE
Fix use of Client.from_url in the docstring for AcmeIssuingService

### DIFF
--- a/src/txacme/service.py
+++ b/src/txacme/service.py
@@ -35,7 +35,7 @@ class AcmeIssuingService(Service):
     :type client_creator: Callable[[], Deferred[`txacme.client.Client`]]
     :param client_creator: A callable called with no arguments
         for creating the ACME client.  For example, ``partial(Client.from_url,
-        reactor=reactor, directory=LETSENCRYPT_STAGING_DIRECTORY, key=acme_key,
+        reactor=reactor, url=LETSENCRYPT_STAGING_DIRECTORY, key=acme_key,
         alg=RS256)``.
     :param clock: ``IReactorTime`` provider; usually the reactor, when not
         testing.


### PR DESCRIPTION
Fixes #67.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mithrandi/txacme/69)
<!-- Reviewable:end -->
